### PR TITLE
Only scan block entities on update

### DIFF
--- a/src/main/java/xyz/xdmatthewbx/chatlog/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/xyz/xdmatthewbx/chatlog/mixin/ClientPlayNetworkHandlerMixin.java
@@ -1,0 +1,21 @@
+package xyz.xdmatthewbx.chatlog.mixin;
+
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import xyz.xdmatthewbx.chatlog.modules.ESPModule;
+
+@Mixin(ClientPlayNetworkHandler.class)
+public class ClientPlayNetworkHandlerMixin {
+
+	@Inject(method = "onBlockEntityUpdate", at = @At("TAIL"))
+	public void onBlockEntityUpdate(BlockEntityUpdateS2CPacket packet, CallbackInfo ci) {
+		if (ESPModule.INSTANCE.enabled) {
+			ESPModule.INSTANCE.cacheBlockPosAsync(packet.getPos().toImmutable());
+		}
+	}
+
+}

--- a/src/main/java/xyz/xdmatthewbx/chatlog/modules/ESPModule.java
+++ b/src/main/java/xyz/xdmatthewbx/chatlog/modules/ESPModule.java
@@ -319,16 +319,6 @@ public class ESPModule extends BaseModule {
 			if (cachedWorld.get() != CLIENT.world)
 				resetBlockCache();
 
-			var chunks = CLIENT.world.getChunkManager().chunks.chunks;
-			for (int i = 0; i < chunks.length(); i++) {
-				var chunk = chunks.get(i);
-				if (chunk == null) continue;
-				try {
-					SCAN_POOL.submit(() ->
-						chunk.getBlockEntities().keySet().forEach(this::cacheBlockPos));
-				} catch (ConcurrentModificationException ignored) { }
-			}
-
 			while (!blockCacheQueue.isEmpty()) {
 				BlockPos block = blockCacheQueue.pop();
 //				cacheBlockPos(block);

--- a/src/main/resources/chatlog.mixins.json
+++ b/src/main/resources/chatlog.mixins.json
@@ -7,6 +7,7 @@
 	"client": [
 		"BackgroundRendererMixin",
 		"CameraMixin",
+		"ClientPlayNetworkHandlerMixin",
 		"GameRendererMixin",
 		"InGameHudMixin",
 		"InGameOverlayRendererMixin",
@@ -17,9 +18,9 @@
 		"MouseMixin",
 		"ScreenMixin",
 		"SharedConstantsMixin",
+		"VoxelShapeMixin",
 		"WorldChunkMixin",
-		"WorldRendererMixin",
-		"VoxelShapeMixin"
+		"WorldRendererMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
Should make block entity filters way less laggy.